### PR TITLE
infer types from controller props

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,9 @@
     "autoload": {
         "classmap": ["lib/"]
     },
+    "autoload-dev": {
+        "classmap": ["tests/classes/"]
+    },
     "require": {
         "rector/rector": "^0.10.4"
     },

--- a/lib/ViewScopeRector.php
+++ b/lib/ViewScopeRector.php
@@ -11,11 +11,25 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Reflection\ReflectionProvider;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-class ViewScopeRector extends AbstractRector {
+class ViewScopeRector extends AbstractRector
+{
+    /**
+     * @var ReflectionProvider
+     */
+    private $reflectionProvider;
+
+    public function __construct(ReflectionProvider $reflectionProvider
+    )
+    {
+        $this->reflectionProvider = $reflectionProvider;
+    }
+
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Infer view scope', [new ConfiguredCodeSample('', '')]);
@@ -47,11 +61,30 @@ array(
             return null;
         }
 
+        $inferredType = $this->inferTypeFromController("\IndexController", $node->exprs[0]->name);
+        if (!$inferredType) {
+            return null;
+        }
+
         // https://github.com/rectorphp/rector/blob/main/docs/how_to_work_with_doc_block_and_comments.md
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-        $phpDocInfo->addTagValueNode(new VarTagValueNode(new IdentifierTypeNode('string'), '$'. $node->exprs[0]->name, ''));
+        $phpDocInfo->addTagValueNode(new VarTagValueNode($inferredType, '$' . $node->exprs[0]->name, ''));
 
         return $node;
+    }
+
+    /**
+     * @param class-string $controllerClass
+     * @param string $propertyName
+     * @throws \PHPStan\Reflection\MissingPropertyFromReflectionException
+     */
+    private function inferTypeFromController($controllerClass, $propertyName): TypeNode
+    {
+        $classReflection = $this->reflectionProvider->getClass($controllerClass);
+        // XXX where to get the $scope from?
+        $propertyReflection = $classReflection->getProperty($propertyName);
+
+        return $propertyReflection->getReadableType();
     }
 
     /*

--- a/lib/ViewScopeRector.php
+++ b/lib/ViewScopeRector.php
@@ -89,6 +89,8 @@ array(
 
         $propertyName = $node->name;
 
+        // XXX ondrey hinted that ClassReflection::getNativeProperty() might be enough
+        // https://github.com/phpstan/phpstan/discussions/4837
         $classReflection = $this->reflectionProvider->getClass($controllerClass);
         $propertyReflection = $classReflection->getProperty($propertyName, $scope);
 

--- a/lib/ViewScopeRector.php
+++ b/lib/ViewScopeRector.php
@@ -79,7 +79,6 @@ array(
 
     /**
      * @param class-string $controllerClass
-     * @param string $propertyName
      * @throws \PHPStan\Reflection\MissingPropertyFromReflectionException
      */
     private function inferTypeFromController($controllerClass, Variable $node): TypeNode

--- a/lib/ViewScopeRector.php
+++ b/lib/ViewScopeRector.php
@@ -4,6 +4,7 @@ namespace ViewScopeRector;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\Variable;
+use PHPStan\Analyser\Scope;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
@@ -14,6 +15,7 @@ use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -61,14 +63,16 @@ array(
             return null;
         }
 
-        $inferredType = $this->inferTypeFromController("\IndexController", $node->exprs[0]->name);
+        $variable = $node->exprs[0];
+
+        $inferredType = $this->inferTypeFromController("\IndexController", $variable);
         if (!$inferredType) {
             return null;
         }
 
         // https://github.com/rectorphp/rector/blob/main/docs/how_to_work_with_doc_block_and_comments.md
         $phpDocInfo = $this->phpDocInfoFactory->createFromNodeOrEmpty($node);
-        $phpDocInfo->addTagValueNode(new VarTagValueNode($inferredType, '$' . $node->exprs[0]->name, ''));
+        $phpDocInfo->addTagValueNode(new VarTagValueNode($inferredType, '$' . $variable->name, ''));
 
         return $node;
     }
@@ -78,13 +82,17 @@ array(
      * @param string $propertyName
      * @throws \PHPStan\Reflection\MissingPropertyFromReflectionException
      */
-    private function inferTypeFromController($controllerClass, $propertyName): TypeNode
+    private function inferTypeFromController($controllerClass, Variable $node): TypeNode
     {
-        $classReflection = $this->reflectionProvider->getClass($controllerClass);
-        // XXX where to get the $scope from?
-        $propertyReflection = $classReflection->getProperty($propertyName);
+        /** @var Scope|null $scope */
+        $scope = $node->getAttribute(AttributeKey::SCOPE);
 
-        return $propertyReflection->getReadableType();
+        $propertyName = $node->name;
+
+        $classReflection = $this->reflectionProvider->getClass($controllerClass);
+        $propertyReflection = $classReflection->getProperty($propertyName, $scope);
+
+        return $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($propertyReflection->getReadableType());
     }
 
     /*


### PR DESCRIPTION
**big picture:**

this rector is meant to introduce `@var` phpdocs into analyzed view files based on declared public properties of a corresponding controller.

example Controller:
```php
class Controller {
   /**
    * @var string
    */
   public $hello;
}
```

example view:
```php
echo $hello;
```

the rector should lookup the controller-class via static reflection, infer the type of its properties and with this knowledge adjust/create a `@var` phpdoc in the view file.

so in the end the rector should change the example view to 
```php
/**
 * @var string
 */
echo $hello;
```

**Challenge:**

the basic mechanics for changing the phpdoc in the view is working in a very simplistic form.
I am at the point where I need the static reflection to work as described above.

the actual problem is, that I don't know where to get the `$scope` from, which [I need to pass](https://github.com/staabm/rector-view-scope/pull/3/files#diff-5415bdc7f4798e8c69ec336de14436ca8810352f7f883bc2438e56a96fe1268eR85) to `ClassReflection->getProperty()`.