### PR TITLE
Refactoring: extracted ContextInferer out of ViewScopeRector

### DIFF
--- a/lib/ContextInferer.php
+++ b/lib/ContextInferer.php
@@ -8,7 +8,8 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 /**
  * @phpstan-template T of Node
  */
-interface ContextInferer {
+interface ContextInferer
+{
     /**
      * Infers the type for the given node
      *

--- a/lib/ContextInferer.php
+++ b/lib/ContextInferer.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ViewScopeRector;
+
+use PhpParser\Node;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+
+/**
+ * @phpstan-template T of Node
+ */
+interface ContextInferer {
+    /**
+     * Infers the type for the given node
+     *
+     * @param T $variable
+     * @return TypeNode|null
+     */
+    public function infer(Node $variable): ?TypeNode;
+}

--- a/lib/ContextInferer.php
+++ b/lib/ContextInferer.php
@@ -11,7 +11,8 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 interface ContextInferer
 {
     /**
-     * Infers the type for the given node
+     * Tries to to infer the type for the given node.
+     * Returns null, when the inferer doesn't know a type of the given node.
      *
      * @param T $variable
      * @return TypeNode|null

--- a/lib/ViewScopeRector.php
+++ b/lib/ViewScopeRector.php
@@ -20,6 +20,7 @@ use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use ViewScopeRector\Inferer\RocketViewContextInferer;
 
 class ViewScopeRector extends AbstractRector
 {
@@ -28,8 +29,7 @@ class ViewScopeRector extends AbstractRector
      */
     private $reflectionProvider;
 
-    public function __construct(ReflectionProvider $reflectionProvider
-    )
+    public function __construct(ReflectionProvider $reflectionProvider)
     {
         $this->reflectionProvider = $reflectionProvider;
     }
@@ -49,20 +49,9 @@ class ViewScopeRector extends AbstractRector
      */
     public function refactor(Node $variable): ?Node
     {
-        if (!$this->isInViewPath($variable)) {
-            return null;
-        }
-        
-        if (!$this->isTopLevelView($variable)) {
-            return null;
-        }
+        $contextInferer = new RocketViewContextInferer($this->reflectionProvider, $this->nodeNameResolver, $this->staticTypeMapper);
 
-        $controllerClass = $this->findMatchingController($variable);
-        if (!$controllerClass) {
-            return null;
-        }
-
-        $inferredType = $this->inferTypeFromController($controllerClass, $variable);
+        $inferredType = $contextInferer->infer($variable);
         if (!$inferredType) {
             // no matching property for the given variable, skip.
             return null;
@@ -73,24 +62,6 @@ class ViewScopeRector extends AbstractRector
         return $variable;
     }
     
-    private function isInViewPath(Variable $variable):bool {
-        // TODO implement me
-        return true;
-    }
-    
-    private function isTopLevelView(Variable $variable):bool {
-        // TODO implement me
-        return true;
-    }
-    
-    /**
-     * @return class-string|null
-     */
-    private function findMatchingController(Variable $variable): ?string {
-        // TODO implement me
-        return "\IndexController";
-    }
-
     /**
      * @return void
      */
@@ -160,32 +131,5 @@ class ViewScopeRector extends AbstractRector
         } while (true);
     }
 
-    /**
-     * @param class-string $controllerClass
-     */
-    private function inferTypeFromController($controllerClass, Variable $node): ?TypeNode
-    {
-        /** @var Scope|null $scope */
-        $scope = $node->getAttribute(AttributeKey::SCOPE);
-        if ($scope === null) {
-            throw new \RuntimeException("should not happen");
-        }
 
-        $propertyName = $this->nodeNameResolver->getName($node);
-        if ($propertyName === null) {
-            throw new \RuntimeException("should not happen");
-        }
-
-        // XXX ondrey hinted that ClassReflection::getNativeProperty() might be enough
-        // https://github.com/phpstan/phpstan/discussions/4837
-        $classReflection = $this->reflectionProvider->getClass($controllerClass);
-
-        try {
-            $propertyReflection = $classReflection->getProperty($propertyName, $scope);
-        } catch (MissingPropertyFromReflectionException $e) {
-            return null;
-        }
-
-        return $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($propertyReflection->getReadableType());
-    }
 }

--- a/lib/ViewScopeRector.php
+++ b/lib/ViewScopeRector.php
@@ -57,7 +57,7 @@ class ViewScopeRector extends AbstractRector
             return null;
         }
 
-        $controllerClass = $this->findMatchingController($variable));
+        $controllerClass = $this->findMatchingController($variable);
         if (!$controllerClass) {
             return null;
         }

--- a/lib/ViewScopeRector.php
+++ b/lib/ViewScopeRector.php
@@ -61,14 +61,14 @@ class ViewScopeRector extends AbstractRector
 
         return $variable;
     }
-    
+
     /**
      * @return void
      */
     private function declareClassLevelDocBlock(Variable $variable, TypeNode $inferredType)
     {
         $statement = $this->findFirstViewStatement($variable);
-        
+
         $variableName = $this->nodeNameResolver->getName($variable);
         if ($variableName === null) {
             throw new \RuntimeException("should not happen");

--- a/lib/ViewScopeRector.php
+++ b/lib/ViewScopeRector.php
@@ -75,10 +75,12 @@ class ViewScopeRector extends AbstractRector
     
     private function isInViewPath(Variable $variable):bool {
         // TODO implement me
+        return true;
     }
     
     private function isTopLevelView(Variable $variable):bool {
         // TODO implement me
+        return true;
     }
     
     /**
@@ -86,6 +88,7 @@ class ViewScopeRector extends AbstractRector
      */
     private function findMatchingController(Variable $variable): ?string {
         // TODO implement me
+        return "\IndexController";
     }
 
     /**

--- a/lib/ViewScopeRector.php
+++ b/lib/ViewScopeRector.php
@@ -60,8 +60,21 @@ array(
     )
 )
         */
+        
+        if (!$this->isInViewPath($variable)) {
+            return null;
+        }
+        
+        if (!$this->isTopLevelView($variable)) {
+            return null;
+        }
 
-        $inferredType = $this->inferTypeFromController("\IndexController", $variable);
+        $controllerClass = $this->findMatchingController($variable));
+        if (!$controllerClass) {
+            return null;
+        }
+
+        $inferredType = $this->inferTypeFromController($controllerClass, $variable);
         if (!$inferredType) {
             // no matching property for the given variable, skip.
             return null;
@@ -70,6 +83,21 @@ array(
         $this->declareClassLevelDocBlock($variable, $inferredType);
 
         return $variable;
+    }
+    
+    private function isInViewPath(Variable $variable):bool {
+        // TODO implement me
+    }
+    
+    private function isTopLevelView(Variable $variable):bool {
+        // TODO implement me
+    }
+    
+    /**
+     * @return class-string|null
+     */
+    private function findMatchingController(Variable $variable): ?string {
+        // TODO implement me
     }
 
     private function declareClassLevelDocBlock(Variable $variable, TypeNode $inferredType)

--- a/lib/inferer/RocketViewContextInferer.php
+++ b/lib/inferer/RocketViewContextInferer.php
@@ -16,7 +16,8 @@ use ViewScopeRector\ContextInferer;
 /**
  * @implements ContextInferer<Variable>
  */
-final class RocketViewContextInferer implements ContextInferer {
+final class RocketViewContextInferer implements ContextInferer
+{
     /**
      * @var ReflectionProvider
      */
@@ -30,7 +31,8 @@ final class RocketViewContextInferer implements ContextInferer {
      */
     private $staticTypeMapper;
 
-    public function __construct(ReflectionProvider $reflectionProvider, NodeNameResolver $nodeNameResolver, StaticTypeMapper $staticTypeMapper) {
+    public function __construct(ReflectionProvider $reflectionProvider, NodeNameResolver $nodeNameResolver, StaticTypeMapper $staticTypeMapper)
+    {
         $this->reflectionProvider = $reflectionProvider;
         $this->nodeNameResolver = $nodeNameResolver;
         $this->staticTypeMapper = $staticTypeMapper;
@@ -58,12 +60,14 @@ final class RocketViewContextInferer implements ContextInferer {
         return $this->inferTypeFromController($controllerClass, $variable);
     }
 
-    private function isInViewPath(Variable $variable):bool {
+    private function isInViewPath(Variable $variable): bool
+    {
         // TODO implement me
         return true;
     }
 
-    private function isTopLevelView(Variable $variable):bool {
+    private function isTopLevelView(Variable $variable): bool
+    {
         // TODO implement me
         return true;
     }

--- a/lib/inferer/RocketViewContextInferer.php
+++ b/lib/inferer/RocketViewContextInferer.php
@@ -78,10 +78,10 @@ final class RocketViewContextInferer implements ContextInferer
     private function findMatchingController(Variable $variable): ?string
     {
         // TODO implement me
-        if ($variable) {
-            return "\IndexController";
+        if ($variable->name == "hansipansi") {
+            return null;
         }
-        return null;
+        return "\IndexController";
     }
 
     /**

--- a/lib/inferer/RocketViewContextInferer.php
+++ b/lib/inferer/RocketViewContextInferer.php
@@ -78,7 +78,10 @@ final class RocketViewContextInferer implements ContextInferer
     private function findMatchingController(Variable $variable): ?string
     {
         // TODO implement me
-        return "\IndexController";
+        if ($variable) {
+            return "\IndexController";
+        }
+        return null;
     }
 
     /**

--- a/lib/inferer/RocketViewContextInferer.php
+++ b/lib/inferer/RocketViewContextInferer.php
@@ -78,10 +78,10 @@ final class RocketViewContextInferer implements ContextInferer
     private function findMatchingController(Variable $variable): ?string
     {
         // TODO implement me
-        if ($variable->name == "hansipansi") {
-            return null;
+        if ($variable->name != "hansipansi-nowhere-used-xxx") {
+            return "\IndexController";
         }
-        return "\IndexController";
+        return null;
     }
 
     /**

--- a/lib/inferer/RocketViewContextInferer.php
+++ b/lib/inferer/RocketViewContextInferer.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace ViewScopeRector\Inferer;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Analyser\Scope;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Reflection\MissingPropertyFromReflectionException;
+use PHPStan\Reflection\ReflectionProvider;
+use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\StaticTypeMapper\StaticTypeMapper;
+use ViewScopeRector\ContextInferer;
+
+/**
+ * @implements ContextInferer<Variable>
+ */
+final class RocketViewContextInferer implements ContextInferer {
+    /**
+     * @var ReflectionProvider
+     */
+    private $reflectionProvider;
+    /**
+     * @var NodeNameResolver
+     */
+    private $nodeNameResolver;
+    /**
+     * @var StaticTypeMapper
+     */
+    private $staticTypeMapper;
+
+    public function __construct(ReflectionProvider $reflectionProvider, NodeNameResolver $nodeNameResolver, StaticTypeMapper $staticTypeMapper) {
+        $this->reflectionProvider = $reflectionProvider;
+        $this->nodeNameResolver = $nodeNameResolver;
+        $this->staticTypeMapper = $staticTypeMapper;
+    }
+
+    public function infer(Node $variable): ?TypeNode
+    {
+        if (!$variable instanceof Variable) {
+            throw new \RuntimeException("should not happen");
+        }
+
+        if (!$this->isInViewPath($variable)) {
+            return null;
+        }
+
+        if (!$this->isTopLevelView($variable)) {
+            return null;
+        }
+
+        $controllerClass = $this->findMatchingController($variable);
+        if (!$controllerClass) {
+            return null;
+        }
+
+        return $this->inferTypeFromController($controllerClass, $variable);
+    }
+
+    private function isInViewPath(Variable $variable):bool {
+        // TODO implement me
+        return true;
+    }
+
+    private function isTopLevelView(Variable $variable):bool {
+        // TODO implement me
+        return true;
+    }
+
+    /**
+     * @return class-string|null
+     */
+    private function findMatchingController(Variable $variable): ?string
+    {
+        // TODO implement me
+        return "\IndexController";
+    }
+
+    /**
+     * @param class-string $controllerClass
+     */
+    private function inferTypeFromController($controllerClass, Variable $node): ?TypeNode
+    {
+        /** @var Scope|null $scope */
+        $scope = $node->getAttribute(AttributeKey::SCOPE);
+        if ($scope === null) {
+            throw new \RuntimeException("should not happen");
+        }
+
+        $propertyName = $this->nodeNameResolver->getName($node);
+        if ($propertyName === null) {
+            throw new \RuntimeException("should not happen");
+        }
+
+        // XXX ondrey hinted that ClassReflection::getNativeProperty() might be enough
+        // https://github.com/phpstan/phpstan/discussions/4837
+        $classReflection = $this->reflectionProvider->getClass($controllerClass);
+
+        try {
+            $propertyReflection = $classReflection->getProperty($propertyName, $scope);
+        } catch (MissingPropertyFromReflectionException $e) {
+            return null;
+        }
+
+        return $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($propertyReflection->getReadableType());
+    }
+}


### PR DESCRIPTION
decouple ViewScopeRector from the context which inferes the type.