### PR TITLE
utilize static reflection

### DIFF
--- a/builtin/controllers/AdmgrpController.php
+++ b/builtin/controllers/AdmgrpController.php
@@ -1,4 +1,9 @@
 <?php
 
 class AdmgrpController 
-{}
+{
+    /**
+     * @var string
+     */
+    public $myspecialtest;
+}

--- a/builtin/controllers/AdmgrpController.php
+++ b/builtin/controllers/AdmgrpController.php
@@ -1,0 +1,4 @@
+<?php
+
+class AdmgrpController 
+{}

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+    "name": "staabm/rector-view-scope",
     "license": "MIT",
     "autoload": {
         "classmap": ["lib/"]

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,7 @@
     },
     "autoload-dev": {
         "classmap": [
-            "tests/classes/",
-            "builtin/"
+            "tests/classes/"
         ]
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,14 @@
         "classmap": ["lib/"]
     },
     "autoload-dev": {
-        "classmap": ["tests/classes/"]
+        "classmap": [
+            "tests/classes/",
+            "builtin/"
+        ]
     },
     "require": {
         "php": ">=7.4",
-        "rector/rector": "^0.10.4"
+        "rector/rector": "^0.10.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require": {
         "php": ">=7.4",
-        "rector/rector": "^0.10.6"
+        "rector/rector": "dev-fix-autolaod-in-tests as 0.10.12-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require": {
         "php": ">=7.4",
-        "rector/rector": "dev-fix-autolaod-in-tests as 0.10.12-dev"
+        "rector/rector": "dev-main as 0.10.12-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/lib/ViewScopeRector.php
+++ b/lib/ViewScopeRector.php
@@ -16,6 +16,7 @@ use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\MissingPropertyFromReflectionException;
 use PHPStan\Reflection\ReflectionProvider;
+use Rector\Core\Provider\CurrentFileProvider;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\AbstractCodeSample;
@@ -30,9 +31,15 @@ class ViewScopeRector extends AbstractRector
      */
     private $reflectionProvider;
 
-    public function __construct(ReflectionProvider $reflectionProvider)
+    /**
+     * @var CurrentFileProvider
+     */
+    private $currentFileProvider;
+
+    public function __construct(ReflectionProvider $reflectionProvider, CurrentFileProvider $currentFileProvider)
     {
         $this->reflectionProvider = $reflectionProvider;
+        $this->currentFileProvider = $currentFileProvider;
     }
 
     public function getRuleDefinition(): RuleDefinition
@@ -50,7 +57,17 @@ class ViewScopeRector extends AbstractRector
      */
     public function refactor(Node $variable): ?Node
     {
-        $contextInferer = new RocketViewContextInferer($this->reflectionProvider, $this->nodeNameResolver, $this->staticTypeMapper);
+        $controllerClass = "AdmgrpController";
+        try {
+            $classReflection = $this->reflectionProvider->getClass($controllerClass);
+            var_dump($classReflection);
+        } catch (\Throwable $e) {
+            var_dump($e->getMessage());
+        }
+
+        return null;
+
+        $contextInferer = new RocketViewContextInferer($this->reflectionProvider, $this->nodeNameResolver, $this->staticTypeMapper, $this->currentFileProvider);
 
         $inferredType = $contextInferer->infer($variable);
         if (!$inferredType) {

--- a/lib/ViewScopeRector.php
+++ b/lib/ViewScopeRector.php
@@ -57,16 +57,6 @@ class ViewScopeRector extends AbstractRector
      */
     public function refactor(Node $variable): ?Node
     {
-        $controllerClass = "AdmgrpController";
-        try {
-            $classReflection = $this->reflectionProvider->getClass($controllerClass);
-            var_dump(get_class($classReflection));
-        } catch (\Throwable $e) {
-            var_dump($e->getMessage());
-        }
-exit();
-        return null;
-
         $contextInferer = new RocketViewContextInferer($this->reflectionProvider, $this->nodeNameResolver, $this->staticTypeMapper, $this->currentFileProvider);
 
         $inferredType = $contextInferer->infer($variable);

--- a/lib/ViewScopeRector.php
+++ b/lib/ViewScopeRector.php
@@ -60,11 +60,11 @@ class ViewScopeRector extends AbstractRector
         $controllerClass = "AdmgrpController";
         try {
             $classReflection = $this->reflectionProvider->getClass($controllerClass);
-            var_dump($classReflection);
+            var_dump(get_class($classReflection));
         } catch (\Throwable $e) {
             var_dump($e->getMessage());
         }
-
+exit();
         return null;
 
         $contextInferer = new RocketViewContextInferer($this->reflectionProvider, $this->nodeNameResolver, $this->staticTypeMapper, $this->currentFileProvider);

--- a/lib/inferer/RocketViewContextInferer.php
+++ b/lib/inferer/RocketViewContextInferer.php
@@ -108,16 +108,15 @@ final class RocketViewContextInferer implements ContextInferer
 
         // XXX ondrey hinted that ClassReflection::getNativeProperty() might be enough
         // https://github.com/phpstan/phpstan/discussions/4837
-        try {
-            $classReflection = $this->reflectionProvider->getClass($controllerClass);
-        } catch (\Throwable $e) {
-            var_dump($e->getMessage());
-        }
 
         try {
+            $classReflection = $this->reflectionProvider->getClass($controllerClass);
             $propertyReflection = $classReflection->getProperty($propertyName, $scope);
         } catch (MissingPropertyFromReflectionException $e) {
+            var_dump($e->getMessage());
             return null;
+        } catch (\Throwable $e) {
+            var_dump($e->getMessage());
         }
 
         return $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($propertyReflection->getReadableType());

--- a/lib/inferer/RocketViewContextInferer.php
+++ b/lib/inferer/RocketViewContextInferer.php
@@ -81,11 +81,11 @@ final class RocketViewContextInferer implements ContextInferer
     {
         // TODO implement me
         if ($variable->name == "myspecialtest") {
-            return "AdmgrpController";
+            return '\AdmgrpController';
         }
 
         if ($variable->name != "hansipansi-nowhere-used-xxx") {
-            return "IndexController";
+            return '\IndexController';
         }
         return null;
     }

--- a/lib/inferer/RocketViewContextInferer.php
+++ b/lib/inferer/RocketViewContextInferer.php
@@ -94,7 +94,7 @@ final class RocketViewContextInferer implements ContextInferer
         return null;
     }
 
-    private function inferTypeFromController(string $controllerClass, Variable $node): TypeNode
+    private function inferTypeFromController(string $controllerClass, Variable $node): ?TypeNode
     {
         /** @var Scope|null $scope */
         $scope = $node->getAttribute(AttributeKey::SCOPE);
@@ -110,9 +110,13 @@ final class RocketViewContextInferer implements ContextInferer
         // XXX ondrey hinted that ClassReflection::getNativeProperty() might be enough
         // https://github.com/phpstan/phpstan/discussions/4837
 
-        $classReflection = $this->reflectionProvider->getClass($controllerClass);
-        $propertyReflection = $classReflection->getProperty($propertyName, $scope);
+        try {
+            $classReflection = $this->reflectionProvider->getClass($controllerClass);
+            $propertyReflection = $classReflection->getProperty($propertyName, $scope);
 
-        return $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($propertyReflection->getReadableType());
+            return $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($propertyReflection->getReadableType());
+        } catch (MissingPropertyFromReflectionException $e) {
+            return null;
+        }
     }
 }

--- a/lib/inferer/RocketViewContextInferer.php
+++ b/lib/inferer/RocketViewContextInferer.php
@@ -94,10 +94,7 @@ final class RocketViewContextInferer implements ContextInferer
         return null;
     }
 
-    /**
-     * @param class-string $controllerClass
-     */
-    private function inferTypeFromController($controllerClass, Variable $node): ?TypeNode
+    private function inferTypeFromController(string $controllerClass, Variable $node): ?TypeNode
     {
         /** @var Scope|null $scope */
         $scope = $node->getAttribute(AttributeKey::SCOPE);
@@ -116,7 +113,7 @@ final class RocketViewContextInferer implements ContextInferer
         try {
             $classReflection = $this->reflectionProvider->getClass($controllerClass);
             $propertyReflection = $classReflection->getProperty($propertyName, $scope);
-            
+
             return $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($propertyReflection->getReadableType());
         } catch (MissingPropertyFromReflectionException $e) {
             var_dump($e->getMessage());

--- a/lib/inferer/RocketViewContextInferer.php
+++ b/lib/inferer/RocketViewContextInferer.php
@@ -110,17 +110,9 @@ final class RocketViewContextInferer implements ContextInferer
         // XXX ondrey hinted that ClassReflection::getNativeProperty() might be enough
         // https://github.com/phpstan/phpstan/discussions/4837
 
-        try {
-            $classReflection = $this->reflectionProvider->getClass($controllerClass);
-            $propertyReflection = $classReflection->getProperty($propertyName, $scope);
+        $classReflection = $this->reflectionProvider->getClass($controllerClass);
+        $propertyReflection = $classReflection->getProperty($propertyName, $scope);
 
-            return $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($propertyReflection->getReadableType());
-        } catch (MissingPropertyFromReflectionException $e) {
-            var_dump($e->getMessage());
-        } catch (\Throwable $e) {
-            var_dump($e->getMessage());
-        }
-
-        return null;
+        return $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($propertyReflection->getReadableType());
     }
 }

--- a/lib/inferer/RocketViewContextInferer.php
+++ b/lib/inferer/RocketViewContextInferer.php
@@ -116,13 +116,14 @@ final class RocketViewContextInferer implements ContextInferer
         try {
             $classReflection = $this->reflectionProvider->getClass($controllerClass);
             $propertyReflection = $classReflection->getProperty($propertyName, $scope);
+            
+            return $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($propertyReflection->getReadableType());
         } catch (MissingPropertyFromReflectionException $e) {
             var_dump($e->getMessage());
-            return null;
         } catch (\Throwable $e) {
             var_dump($e->getMessage());
         }
 
-        return $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($propertyReflection->getReadableType());
+        return null;
     }
 }

--- a/lib/inferer/RocketViewContextInferer.php
+++ b/lib/inferer/RocketViewContextInferer.php
@@ -80,8 +80,12 @@ final class RocketViewContextInferer implements ContextInferer
     private function findMatchingController(Variable $variable): ?string
     {
         // TODO implement me
+        if ($variable->name == "myspecialtest") {
+            return "AdmgrpController";
+        }
+
         if ($variable->name != "hansipansi-nowhere-used-xxx") {
-            return "\IndexController";
+            return "IndexController";
         }
         return null;
     }
@@ -104,7 +108,11 @@ final class RocketViewContextInferer implements ContextInferer
 
         // XXX ondrey hinted that ClassReflection::getNativeProperty() might be enough
         // https://github.com/phpstan/phpstan/discussions/4837
-        $classReflection = $this->reflectionProvider->getClass($controllerClass);
+        try {
+            $classReflection = $this->reflectionProvider->getClass($controllerClass);
+        } catch (\Throwable $e) {
+            var_dump($e->getMessage());
+        }
 
         try {
             $propertyReflection = $classReflection->getProperty($propertyName, $scope);

--- a/lib/inferer/RocketViewContextInferer.php
+++ b/lib/inferer/RocketViewContextInferer.php
@@ -8,6 +8,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\Reflection\MissingPropertyFromReflectionException;
 use PHPStan\Reflection\ReflectionProvider;
+use Rector\Core\Provider\CurrentFileProvider;
 use Rector\NodeNameResolver\NodeNameResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\StaticTypeMapper\StaticTypeMapper;
@@ -33,11 +34,17 @@ final class RocketViewContextInferer implements ContextInferer
      */
     private $staticTypeMapper;
 
-    public function __construct(ReflectionProvider $reflectionProvider, NodeNameResolver $nodeNameResolver, StaticTypeMapper $staticTypeMapper)
+    /**
+     * @var CurrentFileProvider
+     */
+    private $currentFileProvider;
+
+    public function __construct(ReflectionProvider $reflectionProvider, NodeNameResolver $nodeNameResolver, StaticTypeMapper $staticTypeMapper, CurrentFileProvider $currentFileProvider)
     {
         $this->reflectionProvider = $reflectionProvider;
         $this->nodeNameResolver = $nodeNameResolver;
         $this->staticTypeMapper = $staticTypeMapper;
+        $this->currentFileProvider = $currentFileProvider;
     }
 
     public function infer(Node $variable): ?TypeNode
@@ -74,9 +81,6 @@ final class RocketViewContextInferer implements ContextInferer
         return true;
     }
 
-    /**
-     * @return class-string|null
-     */
     private function findMatchingController(Variable $variable): ?string
     {
         // TODO implement me

--- a/lib/inferer/RocketViewContextInferer.php
+++ b/lib/inferer/RocketViewContextInferer.php
@@ -94,7 +94,7 @@ final class RocketViewContextInferer implements ContextInferer
         return null;
     }
 
-    private function inferTypeFromController(string $controllerClass, Variable $node): ?TypeNode
+    private function inferTypeFromController(string $controllerClass, Variable $node): TypeNode
     {
         /** @var Scope|null $scope */
         $scope = $node->getAttribute(AttributeKey::SCOPE);

--- a/myautoload.php
+++ b/myautoload.php
@@ -1,3 +1,5 @@
 <?php
 
-require_once __DIR__.'/builtin/controllers/AdmgrpController.php';
+spl_autoload_register(function ($class) {
+    require_once __DIR__.'/builtin/controllers/AdmgrpController.php';
+});

--- a/myautoload.php
+++ b/myautoload.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__.'/builtin/controllers/AdmgrpController.php';

--- a/tests/Fixture/infer-admgrp.php.inc
+++ b/tests/Fixture/infer-admgrp.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @var int $myspecialtest
+ */
+echo $myspecialtest;
+-----
+<?php
+
+/**
+ * @var string $myspecialtest
+ */
+echo $myspecialtest;

--- a/tests/config/configured_rule.php
+++ b/tests/config/configured_rule.php
@@ -11,5 +11,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(\ViewScopeRector\ViewScopeRector::class);
 
-    $parameters->set(Option::AUTOLOAD_PATHS, [ __DIR__.'/../../myautoload.php']);
+    $parameters->set(Option::BOOTSTRAP_FILES, [ __DIR__.'/../../myautoload.php']);
 };

--- a/tests/config/configured_rule.php
+++ b/tests/config/configured_rule.php
@@ -11,5 +11,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(\ViewScopeRector\ViewScopeRector::class);
 
-    $parameters->set(Option::AUTOLOAD_PATHS, [__DIR__.'/../../myautoload.php']);
+    $parameters->set(Option::BOOTSTRAP_FILES, [__DIR__.'/../../myautoload.php']);
 };

--- a/tests/config/configured_rule.php
+++ b/tests/config/configured_rule.php
@@ -11,5 +11,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(\ViewScopeRector\ViewScopeRector::class);
 
-    $parameters->set(Option::OPTION_AUTOLOAD_FILE, __DIR__.'/../../myautoload.php');
+    $parameters->set(Option::AUTOLOAD_PATHS, [ __DIR__.'/../../myautoload.php']);
 };

--- a/tests/config/configured_rule.php
+++ b/tests/config/configured_rule.php
@@ -11,5 +11,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(\ViewScopeRector\ViewScopeRector::class);
 
-    $parameters->set(Option::BOOTSTRAP_FILES, [__DIR__.'/../../myautoload.php']);
+    $parameters->set(Option::OPTION_AUTOLOAD_FILE, __DIR__.'/../../myautoload.php');
 };

--- a/tests/config/configured_rule.php
+++ b/tests/config/configured_rule.php
@@ -3,9 +3,13 @@
 declare(strict_types=1);
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Rector\Core\Configuration\Option;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
+    $parameters = $containerConfigurator->parameters();
 
     $services->set(\ViewScopeRector\ViewScopeRector::class);
+
+    $parameters->set(Option::AUTOLOAD_PATHS, [__DIR__.'/../../myautoload.php']);
 };


### PR DESCRIPTION
I want to use phpstans static reflection from within rector.
therefore I am using the `ReflectionProvider`.

I try to use static reflection on a class which is known to rector because of the `Option::AUTOLOAD_PATHS` setting.
I have the feeling that the `ReflectionProvider` does not know about the extended autoloading path and therefore doesn't know about my class. when using regular composer autoloading the `ReflectionProvider` works like expected.

my custom rector rule wors like expected on the master branch, without the above changes from the pull request.

see https://github.com/staabm/rector-view-scope/pull/19/checks?check_run_id=2344143165 for the actual error

![image](https://user-images.githubusercontent.com/47448731/114730032-cbf17980-9d40-11eb-9d5a-87d07837a31a.png)
