### PR TITLE
added a failling testcase, when phpstart-tags are missing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require": {
         "php": ">=7.4",
-        "rector/rector": "^0.11"
+        "rector/rector": "^0.11.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/tests/rector/Fixture/missing-start.php.inc
+++ b/tests/rector/Fixture/missing-start.php.inc
@@ -1,0 +1,9 @@
+<h1><?php echo $hello; ?></h1>
+-----
+<?php
+
+/**
+ * @var string $hello
+ */
+?>
+<h1><?php echo $hello; ?></h1>

--- a/tests/rector/Fixture/missing-start.php.inc
+++ b/tests/rector/Fixture/missing-start.php.inc
@@ -1,7 +1,6 @@
 <h1><?php echo $hello; ?></h1>
 -----
 <?php
-
 /**
  * @var string $hello
  */


### PR DESCRIPTION
php-file
```
<h1><?php echo $hello; ?></h1>
```

AST of the failing test:
```
array(
    0: Stmt_InlineHTML(
        value: <h1>
    )
    1: Stmt_Echo(
        exprs: array(
            0: Expr_Variable(
                name: hello
            )
        )
    )
    2: Stmt_InlineHTML(
        value: </h1>
    -----

    )
    3: Stmt_Nop(
    )
    4: Stmt_InlineHTML(
        value: <h1>
    )
    5: Stmt_Echo(
        exprs: array(
            0: Expr_Variable(
                name: hello
            )
        )
    )
    6: Stmt_InlineHTML(
        value: </h1>

    )
)
```

it seems rectors phpdoc api atm cannot add phpdoc tag-values to a `Stmt_InlineHTML` node

https://github.com/staabm/rector-view-scope/blob/6489faabe91ffd3edcd9fc49dab2653cecd93f7b/lib/ViewScopeRector.php#L102-L125

see the full test-fixture in the changed-files tab.