### PR TITLE
fix compat with latest rector release

### DIFF
--- a/lib/inferer/rocket/ViewContextInferer.php
+++ b/lib/inferer/rocket/ViewContextInferer.php
@@ -10,6 +10,7 @@ use PHPStan\Reflection\MissingPropertyFromReflectionException;
 use PHPStan\Reflection\ReflectionProvider;
 use Rector\Core\Provider\CurrentFileProvider;
 use Rector\NodeNameResolver\NodeNameResolver;
+use Rector\PHPStanStaticTypeMapper\ValueObject\TypeKind;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\StaticTypeMapper\StaticTypeMapper;
 use ViewScopeRector\ContextInferer;
@@ -76,7 +77,7 @@ final class ViewContextInferer implements ContextInferer
             $classReflection = $this->reflectionProvider->getClass($controllerClass);
             $propertyReflection = $classReflection->getNativeProperty($propertyName);
 
-            return $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($propertyReflection->getReadableType());
+            return $this->staticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode($propertyReflection->getReadableType(), TypeKind::PROPERTY());
         } catch (MissingPropertyFromReflectionException $e) {
             return null;
         }


### PR DESCRIPTION
```
[refactoring] app/modeo/views/account/login.php
    [applying] ViewScopeRector\ViewScopeRector
Too few arguments to function Rector\StaticTypeMapper\StaticTypeMapper::mapPHPStanTypeToPHPStanPhpDocTypeNode(), 1 passed in C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\staabm\rector-view-scope\lib\inferer\rocket\ViewContextInferer.php on line 83 and exactly 2 expected
#0 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\staabm\rector-view-scope\lib\inferer\rocket\ViewContextInferer.php(83): Rector\StaticTypeMapper\StaticTypeMapper->mapPHPStanTypeToPHPStanPhpDocTypeNode(Object(PHPStan\Type\MixedType))
#1 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\staabm\rector-view-scope\lib\inferer\rocket\ViewContextInferer.php(65): ViewScopeRector\Inferer\Rocket\ViewContextInferer->inferTypeFromController('\\AccountControl...', Object(PhpParser\Node\Expr\Variable))
#2 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\staabm\rector-view-scope\lib\ViewScopeRector.php(86): ViewScopeRector\Inferer\Rocket\ViewContextInferer->infer(Object(PhpParser\Node\Expr\Variable))
#3 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\src\Rector\AbstractRector.php(254): ViewScopeRector\ViewScopeRector->refactor(Object(PhpParser\Node\Expr\Variable))
#4 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\vendor\nikic\php-parser\lib\PhpParser\NodeTraverser.php(113): Rector\Core\Rector\AbstractRector->enterNode(Object(PhpParser\Node\Expr\Variable))
#5 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\vendor\nikic\php-parser\lib\PhpParser\NodeTraverser.php(133): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Expr\MethodCall))
#6 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\vendor\nikic\php-parser\lib\PhpParser\NodeTraverser.php(196): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\If_))
#7 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\vendor\nikic\php-parser\lib\PhpParser\NodeTraverser.php(105): PhpParser\NodeTraverser->traverseArray(Array)
#8 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\vendor\nikic\php-parser\lib\PhpParser\NodeTraverser.php(196): PhpParser\NodeTraverser->traverseNode(Object(Rector\Core\PhpParser\Node\CustomNode\FileWithoutNamespace))
#9 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\vendor\nikic\php-parser\lib\PhpParser\NodeTraverser.php(85): PhpParser\NodeTraverser->traverseArray(Array)
#10 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\src\PhpParser\NodeTraverser\RectorNodeTraverser.php(44): PhpParser\NodeTraverser->traverse(Array)
#11 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\src\Application\FileProcessor.php(53): Rector\Core\PhpParser\NodeTraverser\RectorNodeTraverser->traverse(Array)
#12 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\src\Application\FileProcessor\PhpFileProcessor.php(121): Rector\Core\Application\FileProcessor->refactor(Object(Rector\Core\ValueObject\Application\File))
#13 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\src\Application\FileProcessor\PhpFileProcessor.php(133): Rector\Core\Application\FileProcessor\PhpFileProcessor->Rector\Core\Application\FileProcessor\{closure}(Object(Rector\Core\ValueObject\Application\File))
#14 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\src\Application\FileProcessor\PhpFileProcessor.php(122): Rector\Core\Application\FileProcessor\PhpFileProcessor->tryCatchWrapper(Object(Rector\Core\ValueObject\Application\File), Object(Closure), Object(Rector\Core\Enum\ApplicationPhase))
#15 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\src\Application\FileProcessor\PhpFileProcessor.php(83): Rector\Core\Application\FileProcessor\PhpFileProcessor->refactorNodesWithRectors(Object(Rector\Core\ValueObject\Application\File))
#16 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\src\Application\ApplicationFileProcessor.php(76): Rector\Core\Application\FileProcessor\PhpFileProcessor->process(Object(Rector\Core\ValueObject\Application\File), Object(Rector\Core\ValueObject\Configuration))
#17 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\src\Application\ApplicationFileProcessor.php(57): Rector\Core\Application\ApplicationFileProcessor->processFiles(Array, Object(Rector\Core\ValueObject\Configuration))
#18 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\src\Console\Command\ProcessCommand.php(125): Rector\Core\Application\ApplicationFileProcessor->run(Array, Object(Rector\Core\ValueObject\Configuration))
#19 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\vendor\symfony\console\Command\Command.php(274): Rector\Core\Console\Command\ProcessCommand->execute(Object(RectorPrefix20210710\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20210710\Symfony\Component\Console\Output\ConsoleOutput))
#20 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\vendor\symfony\console\Application.php(870): RectorPrefix20210710\Symfony\Component\Console\Command\Command->run(Object(RectorPrefix20210710\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20210710\Symfony\Component\Console\Output\ConsoleOutput))
#21 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\vendor\symfony\console\Application.php(266): RectorPrefix20210710\Symfony\Component\Console\Application->doRunCommand(Object(Rector\Core\Console\Command\ProcessCommand), Object(RectorPrefix20210710\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20210710\Symfony\Component\Console\Output\ConsoleOutput))
#22 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\src\Console\ConsoleApplication.php(71): RectorPrefix20210710\Symfony\Component\Console\Application->doRun(Object(RectorPrefix20210710\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20210710\Symfony\Component\Console\Output\ConsoleOutput))
#23 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\vendor\symfony\console\Application.php(162): Rector\Core\Console\ConsoleApplication->doRun(Object(RectorPrefix20210710\Symfony\Component\Console\Input\ArgvInput), Object(RectorPrefix20210710\Symfony\Component\Console\Output\ConsoleOutput))
#24 C:\Users\mstaab\Documents\GitHub\motiontm\vendor-bin\rector\vendor\rector\rector\bin\rector.php(59): RectorPrefix20210710\Symfony\Component\Console\Application->run()
#25 C:\Users\mstaab\Documents\GitHub\motiontm\vendor\bin\rector(21) : eval()'d code(4): require_once('C:\\Users\\mstaab...')
#26 C:\Users\mstaab\Documents\GitHub\motiontm\vendor\bin\rector(21): eval()
#27 {main}
```

refs https://github.com/rectorphp/rector/issues/6570